### PR TITLE
fix: ESM mocks issue

### DIFF
--- a/mods/__tests__/modA.test.js
+++ b/mods/__tests__/modA.test.js
@@ -1,6 +1,4 @@
 import { jest, it, expect } from '@jest/globals';
-import { modA } from '../index.js';
-import { someService } from '../../services/index.js';
 
 // jest.mock('../../services/someService', () => ({
 //   __esModule: true,
@@ -12,6 +10,9 @@ import { someService } from '../../services/index.js';
 jest.unstable_mockModule('../../services/index.js', () => ({
   someService: jest.fn(),
 }));
+
+const { modA } = await import('../index.js');
+const { someService } = await import('../../services/index.js');
 
 it('should call some service', async () => {
   await modA();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
@neophyt3 Here is a fix for [#12946](https://github.com/facebook/jest/issues/12946).

---

See https://github.com/facebook/jest/issues/10025#issuecomment-716789840. 

ESM modules always evaluate all `import` statements first. In your code, `jest.unstable_mockModule()` was called after modules are evaluate. Hence Jest can mock them.

The change is simple: first call `jest.unstable_mockModule()` and afterwards use `await import()` to load all mocked modules (including the ones which depend on the mocked ones).